### PR TITLE
feat: 로그인 회원가입 기능 API 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-DJANGO_SECRET_KEY=your_secret_key_here
+DJANGO_SECRET_KEY=django-insecure-s@xg+@n3sipsl$z^j!iyowi8^93(0)%v32$&rm4&ga9yugzn8o
 DJANGO_SETTINGS_MODULE=config.settings.local
-ALLOWED_HOSTS=example.com,www.example.com
+ALLOWED_HOSTS=
 DJANGO_SUPERUSER_USERNAME=admin
 DJANGO_SUPERUSER_EMAIL=admin@example.com
-DJANGO_SUPERUSER_PASSWORD=your_secure_password
+DJANGO_SUPERUSER_PASSWORD=cherami77^^

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
-DJANGO_SECRET_KEY=django-insecure-s@xg+@n3sipsl$z^j!iyowi8^93(0)%v32$&rm4&ga9yugzn8o
+DJANGO_SECRET_KEY=your_secret_key_here
 DJANGO_SETTINGS_MODULE=config.settings.local
-ALLOWED_HOSTS=
+ALLOWED_HOSTS=example.com,www.example.com
 DJANGO_SUPERUSER_USERNAME=admin
 DJANGO_SUPERUSER_EMAIL=admin@example.com
-DJANGO_SUPERUSER_PASSWORD=cherami77^^
+DJANGO_SUPERUSER_PASSWORD=your_secure_password

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -1,10 +1,12 @@
 from ninja import NinjaAPI
 from apps.group.api import group_router, group_member_router
+from apps.users.api import users_router
 
 api = NinjaAPI()
 
 api.add_router(prefix="/group", router=group_router)
 api.add_router(prefix="/group", router=group_member_router)
+api.add_router(prefix="/users", router=users_router)
 
 @api.get("/hello")
 def hello(request):

--- a/apps/api/auth.py
+++ b/apps/api/auth.py
@@ -1,0 +1,32 @@
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from django.contrib.auth.models import User
+from django.http import HttpRequest
+from ninja.security import HttpBearer
+
+class JWTAuthHandler:
+    def __init__(self):
+        self.jwt_auth = JWTAuthentication()
+
+    def authenticate(self, request: HttpRequest, token: str) -> User | None:
+        try:
+            validated_token = self.jwt_auth.get_validated_token(token.encode())
+            user = self.jwt_auth.get_user(validated_token)
+            request.user = user
+            return user
+        except Exception:
+            return None
+
+    def get_user_info(self, token: str) -> dict | None:
+        try:
+            validated_token = self.jwt_auth.get_validated_token(token.encode())
+            payload = validated_token.payload
+            return {
+                "user_id": payload.get("user_id"),
+                "username": payload.get("username"),
+            }
+        except Exception:
+            return None
+
+class JWTAuth(HttpBearer):
+    def authenticate(self, request: HttpRequest, token: str):
+        return JWTAuthHandler().authenticate(request, token)

--- a/apps/users/api/__init__.py
+++ b/apps/users/api/__init__.py
@@ -1,0 +1,1 @@
+from .router import router as users_router

--- a/apps/users/api/endpoints.py
+++ b/apps/users/api/endpoints.py
@@ -1,0 +1,98 @@
+from ninja import Router
+from django.contrib.auth.models import User
+from django.contrib.auth import authenticate
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from ninja.security import HttpBearer
+from django.http import HttpRequest
+from apps.users.api.schemas import StandardResponse
+
+from .schemas import SignupSchema, LoginSchema, UpdateUserSchema
+
+router = Router(tags=["Login"])
+
+class JWTAuth(HttpBearer):
+    def authenticate(self, request: HttpRequest, token: str):
+        try:
+            validated_token = JWTAuthentication().get_validated_token(token)
+            user = JWTAuthentication().get_user(validated_token)
+            request.user = user
+            return user
+        except Exception:
+            return None
+
+@router.post("/signup",
+    summary="회원가입 API",
+    description="회원가입을 진행합니다. 이미 존재하는 사용자일 경우 오류를 반환합니다.",
+    response=StandardResponse
+)
+def signup(request, data: SignupSchema):
+    if User.objects.filter(username=data.username).exists():
+        return {"error": "이미 존재하는 사용자입니다."}
+    user = User.objects.create_user(username=data.username, password=data.password)
+    return {"msg": "회원가입 성공", "username": user.username}
+
+@router.post("/login",
+    summary="로그인 API",
+    description="회원가입 시 입력한 username과 password를 넣어 로그인하세요. 응답으로 JWT access/refresh 토큰이 발급됩니다. 헤더에 담아서 인가에 사용하세요.",
+    response=StandardResponse
+)
+def login(request, data: LoginSchema):
+    user = authenticate(username=data.username, password=data.password)
+    if user is None:
+        return {"error": "아이디 또는 비밀번호가 잘못되었습니다."}
+    refresh = RefreshToken.for_user(user)
+    return {
+            "isSuccess": True,
+            "code": "COMMON200",
+            "message": "성공입니다.",
+            "result": {
+                "accessToken": str(refresh.access_token),
+                "refresh": str(refresh),
+            }
+    }
+
+@router.get("/me", auth=JWTAuth(),
+    summary="회원 정보 조회 API",
+    description="현재 회원 정보를 조회합니다. 응답으로 userId와 username을 반환합니다.",
+    response=StandardResponse
+)
+def me(request):
+    return {
+            "isSuccess": True,
+            "code": "COMMON200",
+            "message": "성공입니다.",
+            "result": {
+                "id": request.user.id,
+                "username": request.user.username,
+            }
+    }
+
+
+@router.patch("/me", auth=JWTAuth(),
+    summary="회원 정보 수정 API",
+    description="현재 로그인한 유저의 username 또는 password를 수정합니다. 변경을 원하는 값만 입력해주세요. (변경하지 않을 시, 빈배열 처리"")",
+    response=StandardResponse
+)
+def update_user(request, data: UpdateUserSchema):
+    user = request.user
+
+    if data.username:
+        if User.objects.exclude(id=user.id).filter(username=data.username).exists():
+            return {"error": "이미 존재하는 사용자 이름입니다."}
+        user.username = data.username
+
+    if data.password:
+        user.set_password(data.password)
+
+    user.save()
+
+    return {
+        "isSuccess": True,
+        "code": "COMMON200",
+        "message": "회원 정보가 성공적으로 수정되었습니다.",
+        "result": {
+            "id": user.id,
+            "username": user.username,
+        }
+    }

--- a/apps/users/api/endpoints.py
+++ b/apps/users/api/endpoints.py
@@ -3,25 +3,12 @@ from ninja.responses import Response
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate
 from rest_framework_simplejwt.tokens import RefreshToken
-from rest_framework_simplejwt.authentication import JWTAuthentication
-from ninja.security import HttpBearer
-from django.http import HttpRequest
 
 from apps.api.schema import ResponseSchema
+from apps.api.auth import JWTAuth
 from .schemas import SignupSchema, LoginSchema, UpdateUserSchema
 
 router = Router(tags=["Login"])
-
-
-class JWTAuth(HttpBearer):
-    def authenticate(self, request: HttpRequest, token: str):
-        try:
-            validated_token = JWTAuthentication().get_validated_token(token.encode())
-            user = JWTAuthentication().get_user(validated_token)
-            request.user = user
-            return user
-        except Exception:
-            return None
 
 
 @router.post("/signup", response=ResponseSchema[dict])

--- a/apps/users/api/endpoints.py
+++ b/apps/users/api/endpoints.py
@@ -6,12 +6,12 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from apps.api.schema import ResponseSchema
 from apps.api.auth import JWTAuth
-from .schemas import SignupSchema, LoginSchema, UpdateUserSchema
+from .schemas import SignupSchema, LoginSchema, UpdateUserSchema, UserResponse, SignupResponse, TokenResponse
 
 router = Router(tags=["Login"])
 
 
-@router.post("/signup", response=ResponseSchema[dict])
+@router.post("/signup", response=ResponseSchema[SignupResponse])
 def signup(request, data: SignupSchema):
     if User.objects.filter(username=data.username).exists():
         return Response(
@@ -25,7 +25,7 @@ def signup(request, data: SignupSchema):
     )
 
 
-@router.post("/login", response=ResponseSchema[dict])
+@router.post("/login", response=ResponseSchema[TokenResponse])
 def login(request, data: LoginSchema):
     user = authenticate(username=data.username, password=data.password)
     if user is None:
@@ -47,7 +47,7 @@ def login(request, data: LoginSchema):
     )
 
 
-@router.get("/me", auth=JWTAuth(), response=ResponseSchema[dict])
+@router.get("/me", auth=JWTAuth(), response=ResponseSchema[UserResponse])
 def me(request):
     return Response(
         {
@@ -61,7 +61,7 @@ def me(request):
     )
 
 
-@router.patch("/me", auth=JWTAuth(), response=ResponseSchema[dict])
+@router.patch("/me", auth=JWTAuth(), response=ResponseSchema[UserResponse])
 def update_user(request, data: UpdateUserSchema):
     user = request.user
 

--- a/apps/users/api/endpoints.py
+++ b/apps/users/api/endpoints.py
@@ -1,85 +1,89 @@
 from ninja import Router
+from ninja.responses import Response
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from ninja.security import HttpBearer
 from django.http import HttpRequest
-from apps.users.api.schemas import StandardResponse
 
+from apps.api.schema import ResponseSchema
 from .schemas import SignupSchema, LoginSchema, UpdateUserSchema
 
 router = Router(tags=["Login"])
 
+
 class JWTAuth(HttpBearer):
     def authenticate(self, request: HttpRequest, token: str):
         try:
-            validated_token = JWTAuthentication().get_validated_token(token)
+            validated_token = JWTAuthentication().get_validated_token(token.encode())
             user = JWTAuthentication().get_user(validated_token)
             request.user = user
             return user
         except Exception:
             return None
 
-@router.post("/signup",
-    summary="회원가입 API",
-    description="회원가입을 진행합니다. 이미 존재하는 사용자일 경우 오류를 반환합니다.",
-    response=StandardResponse
-)
+
+@router.post("/signup", response=ResponseSchema[dict])
 def signup(request, data: SignupSchema):
     if User.objects.filter(username=data.username).exists():
-        return {"error": "이미 존재하는 사용자입니다."}
+        return Response(
+            {"message": "이미 존재하는 사용자입니다.", "data": None},
+            status=400
+        )
     user = User.objects.create_user(username=data.username, password=data.password)
-    return {"msg": "회원가입 성공", "username": user.username}
+    return Response(
+        {"message": "회원가입 성공", "data": {"username": user.username}},
+        status=201
+    )
 
-@router.post("/login",
-    summary="로그인 API",
-    description="회원가입 시 입력한 username과 password를 넣어 로그인하세요. 응답으로 JWT access/refresh 토큰이 발급됩니다. 헤더에 담아서 인가에 사용하세요.",
-    response=StandardResponse
-)
+
+@router.post("/login", response=ResponseSchema[dict])
 def login(request, data: LoginSchema):
     user = authenticate(username=data.username, password=data.password)
     if user is None:
-        return {"error": "아이디 또는 비밀번호가 잘못되었습니다."}
+        return Response(
+            {"message": "아이디 또는 비밀번호가 잘못되었습니다.", "data": None},
+            status=401
+        )
+
     refresh = RefreshToken.for_user(user)
-    return {
-            "isSuccess": True,
-            "code": "COMMON200",
-            "message": "성공입니다.",
-            "result": {
+    return Response(
+        {
+            "message": "로그인 성공",
+            "data": {
                 "accessToken": str(refresh.access_token),
                 "refresh": str(refresh),
             }
-    }
+        },
+        status=200
+    )
 
-@router.get("/me", auth=JWTAuth(),
-    summary="회원 정보 조회 API",
-    description="현재 회원 정보를 조회합니다. 응답으로 userId와 username을 반환합니다.",
-    response=StandardResponse
-)
+
+@router.get("/me", auth=JWTAuth(), response=ResponseSchema[dict])
 def me(request):
-    return {
-            "isSuccess": True,
-            "code": "COMMON200",
-            "message": "성공입니다.",
-            "result": {
+    return Response(
+        {
+            "message": "회원 정보 조회 성공",
+            "data": {
                 "id": request.user.id,
                 "username": request.user.username,
             }
-    }
+        },
+        status=200
+    )
 
 
-@router.patch("/me", auth=JWTAuth(),
-    summary="회원 정보 수정 API",
-    description="현재 로그인한 유저의 username 또는 password를 수정합니다. 변경을 원하는 값만 입력해주세요. (변경하지 않을 시, 빈배열 처리"")",
-    response=StandardResponse
-)
+@router.patch("/me", auth=JWTAuth(), response=ResponseSchema[dict])
 def update_user(request, data: UpdateUserSchema):
     user = request.user
 
     if data.username:
         if User.objects.exclude(id=user.id).filter(username=data.username).exists():
-            return {"error": "이미 존재하는 사용자 이름입니다."}
+            return Response(
+                {"message": "이미 존재하는 사용자 이름입니다.", "data": None},
+                status=400
+            )
         user.username = data.username
 
     if data.password:
@@ -87,12 +91,13 @@ def update_user(request, data: UpdateUserSchema):
 
     user.save()
 
-    return {
-        "isSuccess": True,
-        "code": "COMMON200",
-        "message": "회원 정보가 성공적으로 수정되었습니다.",
-        "result": {
-            "id": user.id,
-            "username": user.username,
-        }
-    }
+    return Response(
+        {
+            "message": "회원 정보가 성공적으로 수정되었습니다.",
+            "data": {
+                "id": user.id,
+                "username": user.username,
+            }
+        },
+        status=200
+    )

--- a/apps/users/api/router.py
+++ b/apps/users/api/router.py
@@ -1,0 +1,5 @@
+from ninja import Router
+from .endpoints import router as endpoints_router
+
+router = Router()
+router.add_router("/", endpoints_router)

--- a/apps/users/api/schemas.py
+++ b/apps/users/api/schemas.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Generic, TypeVar
+
+T = TypeVar("T")
+
+class StandardResponse(BaseModel, Generic[T]):
+    isSuccess: bool = True
+    code: str = "COMMON200"
+    message: str = "성공입니다."
+    result: Optional[T] = None
+
+class UserResponse(BaseModel):
+    id: int
+    username: str
+
+class SignupSchema(BaseModel):
+    username: str
+    password: str
+
+class LoginSchema(BaseModel):
+    username: str
+    password: str
+
+class UpdateUserSchema(BaseModel):
+    username: Optional[str] = Field(None, example="newusername")
+    password: Optional[str] = Field(None, example="newpassword")

--- a/apps/users/api/schemas.py
+++ b/apps/users/api/schemas.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, Field
 from typing import Optional, Generic, TypeVar
+from ninja import Schema
 
 T = TypeVar("T")
 
@@ -24,3 +25,10 @@ class LoginSchema(BaseModel):
 class UpdateUserSchema(BaseModel):
     username: Optional[str] = Field(None, example="newusername")
     password: Optional[str] = Field(None, example="newpassword")
+
+class SignupResponse(Schema):
+    username: str
+
+class TokenResponse(Schema):
+    accessToken: str
+    refresh: str

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -45,6 +45,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+
+    'rest_framework',
+    'rest_framework_simplejwt.token_blacklist',
 ]
 
 MIDDLEWARE = [
@@ -143,4 +146,10 @@ CSRF_TRUSTED_ORIGINS = [
 
 NINJA_SETTINGS = {
     "SWAGGER_UI_DIST": "https://cdn.jsdelivr.net/npm/swagger-ui-dist@4.15.5",
+}
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ),
 }

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,8 +17,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from apps.api.api import api
+from rest_framework_simplejwt.views import TokenRefreshView
+
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path("api/", api.urls),
+     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close : #6 

## 📝 작업 사항
1. 회원가입(signup) API 구현
- 기존 사용자 중복 검사 후 신규 사용자 생성
- 성공 시 사용자 명 반환

2. 로그인(login) API 구현
- 사용자 인증 후 JWT Access Token과 Refresh Token 발급
- 인증 실패 시 오류 메시지 반환

3. 현재 로그인한 사용자 정보 조회 API 구현 (/me)
- JWT 인증을 통해 현재 사용자 정보(id, username) 반환

4. 회원 정보 수정 API 구현 (PATCH /me)
- username과 password 변경 가능
- username 중복 시 오류 반환

## ✅ 참고 사항
swagger 테스트 시, 로그인 시 제공되는 Access Token을 복사하여 상단  authorize에서 인증 후, 사용하시면 됩니다.